### PR TITLE
Modify toolchain and CMakeLists in order to correctly build on AS7

### DIFF
--- a/Firmware/App/CMakeLists.txt
+++ b/Firmware/App/CMakeLists.txt
@@ -26,4 +26,7 @@ target_link_libraries(firmware
     HD44780_lcd_driver
 )
 
-add_extra_avr_targets(firmware)
+# Only add those targets if this is used on a Linux environment, as Atmel Studio already handles them itself
+if (UNIX)
+    add_extra_avr_targets(firmware)
+endif()

--- a/Firmware/CMakeLists.txt
+++ b/Firmware/CMakeLists.txt
@@ -7,7 +7,13 @@ project(firmware C)
 set(AVR_MCU atmega328p)
 set(AVR_MCU_SPEED 16000000)
 
-add_definitions(-DF_CPU=${AVR_MCU_SPEED})
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
+
+add_compile_definitions(
+    -DF_CPU=${AVR_MCU_SPEED}
+    -D__AVR_ATmega328P__
+)
 add_compile_options(-mmcu=${AVR_MCU})
 
 set(CMAKE_EXE_LINKER_FLAGS "-mmcu=${AVR_MCU}")


### PR DESCRIPTION
This PR is about Windows Cmake compatibility and provides corrections in order to be able to use the Cmake-AtmelStudio7-Compatibiltiy fork to generate AtmelStudio7 project files.