### PR TITLE
I2c downsizing driver

### DIFF
--- a/Firmware/.vscode/c_cpp_properties.json
+++ b/Firmware/.vscode/c_cpp_properties.json
@@ -180,7 +180,8 @@
                 "/usr/lib/gcc/avr/10.2.0/include"
             ],
             "defines": [
-                "__AVR_ATmega328__"
+                "__AVR_ATmega328__",
+                "I2C_IMPLEM_MASTER_TX"
             ],
             "compilerPath": "/usr/bin/avr-gcc",
             "cStandard": "c11",

--- a/Firmware/App/inc/config.h
+++ b/Firmware/App/inc/config.h
@@ -10,7 +10,7 @@
 #define I2C_DEVICES_COUNT 1U
 
 // Only implement master tx driver
-//#define I2C_IMPLEM_MASTER_TX
+#define I2C_IMPLEM_MASTER_TX
 //#define I2C_IMPLEM_FULL_DRIVER
 
 #endif /* CONFIG_HEADER */

--- a/Firmware/App/inc/config.h
+++ b/Firmware/App/inc/config.h
@@ -9,4 +9,8 @@
 #define TIMEBASE_MAX_MODULES 3U
 #define I2C_DEVICES_COUNT 1U
 
+// Only implement master tx driver
+//#define I2C_IMPLEM_MASTER_TX
+//#define I2C_IMPLEM_FULL_DRIVER
+
 #endif /* CONFIG_HEADER */

--- a/Firmware/CMakeLists.txt
+++ b/Firmware/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_C_STANDARD 11)
 add_compile_definitions(
     F_CPU=${AVR_MCU_SPEED}
     __AVR_ATmega328P__
+    I2C_IMPLEM_MASTER_FULL
 )
 add_compile_options(-mmcu=${AVR_MCU})
 

--- a/Firmware/Drivers/I2c/inc/i2c.h
+++ b/Firmware/Drivers/I2c/inc/i2c.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "i2c_reg.h"
+#include "config.h"
 
 #define I2C_CMD_WRITE_BIT 0U
 #define I2C_CMD_READ_BIT  1U
@@ -18,6 +19,42 @@
 #ifdef __cplusplus
 extern "C"
 {
+#endif
+
+// Available compilation defines to help reduce driver size :
+// I2C_IMPLEM_FULL_DRIVER   /**< Implements the whole driver                    */
+// I2C_IMPLEM_MASTER_FULL   /**< Implements only master handlers (rx + tx)      */
+// I2C_IMPLEM_MASTER_TX     /**< Implements only master tx handler              */
+// I2C_IMPLEM_MASTER_RX     /**< Implements only master rx handler              */
+
+// I2C_IMPLEM_SLAVE_FULL    /**< Implements only slave handlers (rx + tx)      */
+// I2C_IMPLEM_SLAVE_TX      /**< Implements only slave tx handler              */
+// I2C_IMPLEM_SLAVE_RX      /**< Implements only slave rx handler              */
+
+// Checks if no implementation is selected and in case not, defaults to full implementation
+#if !defined(I2C_IMPLEM_FULL_DRIVER)  && !defined(I2C_IMPLEM_MASTER_TX) && !defined(I2C_IMPLEM_MASTER_RX) && !defined(I2C_IMPLEM_SLAVE_TX) && !defined(I2C_IMPLEM_SLAVE_RX) && !defined(I2C_IMPLEM_SLAVE_FULL) && !defined(I2C_IMPLEM_MASTER_FULL)
+#pragma message("No implementation for the I2C driver was specified, defaults to Full implementation (see i2c.h file)")
+#define I2C_IMPLEM_FULL_DRIVER
+#endif
+
+// Sets all implementation preprocessor flags
+#ifdef I2C_IMPLEM_FULL_DRIVER
+#define I2C_IMPLEM_MASTER_TX
+#define I2C_IMPLEM_MASTER_RX
+#define I2C_IMPLEM_SLAVE_TX
+#define I2C_IMPLEM_SLAVE_RX
+#endif
+
+// Sets all master implementations preprocessor flags
+#ifdef I2C_IMPLEM_MASTER_FULL
+#define I2C_IMPLEM_MASTER_TX
+#define I2C_IMPLEM_MASTER_RX
+#endif
+
+// Sets all slave implementations preprocessor flags
+#ifdef I2C_IMPLEM_SLAVE_FULL
+#define I2C_IMPLEM_SLAVE_TX
+#define I2C_IMPLEM_SLAVE_RX
 #endif
 
 
@@ -56,6 +93,7 @@ typedef struct
 typedef enum
 {
     I2C_ERROR_OK,                       /**< Operation is successful                                                  */
+    I2C_ERROR_IMPLEM_DISABLED,          /**< This error is returned whenever application code tries to call a disabled function   */
     I2C_ERROR_NULL_POINTER,             /**< One or more input pointer is set to NULL                                 */
     I2C_ERROR_NULL_HANDLE,              /**< Given handle is not initialised with real addresses                      */
     I2C_ERROR_DEVICE_NOT_FOUND,         /**< Given device id is out of range                                          */

--- a/Firmware/Drivers/I2c/src/i2c.c
+++ b/Firmware/Drivers/I2c/src/i2c.c
@@ -25,6 +25,13 @@
    or 1 for "dumb" devices such as IO Expanders with no Op Code */
 #define MINIMUM_REQUEST_SIZE (1U)
 
+#ifndef I2C_IMPLEM_FULL_DRIVER
+static i2c_error_t i2c_disabled_process(const uint8_t id)
+{
+    (void) id;
+    return I2C_ERROR_IMPLEM_DISABLED;
+}
+#endif
 
 typedef struct
 {
@@ -711,6 +718,11 @@ void i2c_set_state(const uint8_t id, const i2c_state_t state)
 #endif
 
 static i2c_error_t i2c_master_tx_process(const uint8_t id)
+#ifndef I2C_IMPLEM_MASTER_TX
+{
+   return i2c_disabled_process(id);
+}
+#else
 {
     static uint8_t retries = 0;
     i2c_error_t ret = I2C_ERROR_OK;
@@ -818,8 +830,15 @@ static i2c_error_t i2c_master_tx_process(const uint8_t id)
     clear_twint(id);
     return ret;
 }
+#endif
+
 
 static i2c_error_t i2c_master_rx_process(const uint8_t id)
+#ifndef I2C_IMPLEM_MASTER_RX
+{
+   return i2c_disabled_process(id);
+}
+#else
 {
     static uint8_t retries = 0;
     i2c_error_t ret = I2C_ERROR_OK;
@@ -938,8 +957,14 @@ static i2c_error_t i2c_master_rx_process(const uint8_t id)
     clear_twint(id);
     return ret;
 }
+#endif
 
 static i2c_error_t i2c_slave_tx_process(const uint8_t id)
+#ifndef I2C_IMPLEM_SLAVE_TX
+{
+   return i2c_disabled_process(id);
+}
+#else
 {
     static uint8_t retries = 0;
     i2c_error_t ret = I2C_ERROR_OK;
@@ -1054,8 +1079,14 @@ static i2c_error_t i2c_slave_tx_process(const uint8_t id)
     clear_twint(id);
     return ret;
 }
+#endif
 
 static i2c_error_t i2c_slave_rx_process(const uint8_t id)
+#ifndef I2C_IMPLEM_SLAVE_RX
+{
+   return i2c_disabled_process(id);
+}
+#else
 {
     static uint8_t retries = 0;
     static uint8_t processed_bytes = 0;
@@ -1180,6 +1211,7 @@ static i2c_error_t i2c_slave_rx_process(const uint8_t id)
     clear_twint(id);
     return ret;
 }
+#endif
 
 static i2c_error_t process_helper_single(const uint8_t id)
 {

--- a/Firmware/Drivers/I2c/src/i2c.c
+++ b/Firmware/Drivers/I2c/src/i2c.c
@@ -21,7 +21,7 @@
     #include "memutils.h"
 #endif
 
-/* Minimum I2C request size is 2 to account for : 1 op code + 1 read/write data for configurablde devices
+/* Minimum I2C request size is 2 to account for : 1 op code + 1 read/write data for configurable devices
    or 1 for "dumb" devices such as IO Expanders with no Op Code */
 #define MINIMUM_REQUEST_SIZE (1U)
 
@@ -60,7 +60,9 @@ typedef struct
 } i2c_master_buffer_t;
 static i2c_master_buffer_t master_buffer[I2C_DEVICES_COUNT] = {0};
 
+#if defined(I2C_IMPLEM_SLAVE_TX) || defined(I2C_IMPLEM_SLAVE_RX)
 static uint8_t slave_received_bytes[I2C_DEVICES_COUNT] = {0};
+#endif
 
 static inline volatile uint8_t * get_current_master_buffer_byte(const uint8_t id)
 {

--- a/Firmware/Tests/CMakeLists.txt
+++ b/Firmware/Tests/CMakeLists.txt
@@ -9,6 +9,7 @@ enable_testing()
 add_definitions(
     -D__AVR_ATmega328__
     -DUNIT_TESTING
+    -DI2C_IMPLEM_FULL_DRIVER
 )
 
 if(UNIX)


### PR DESCRIPTION
This PR is meant to bring the possibility to break down I2C driver implementation into smaller code blocks to allow reducing its size a bit more, only enabling code sections that we really need.